### PR TITLE
Fix for moose 10

### DIFF
--- a/src/Famix-TypeScript-Entities/FamixTypeScriptContainerEntity.class.st
+++ b/src/Famix-TypeScript-Entities/FamixTypeScriptContainerEntity.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : #FamixTypeScriptContainerEntity,
 	#superclass : #FamixTypeScriptNamedEntity,
-	#traits : 'FamixTWithAnnotationTypes + FamixTWithClasses + FamixTWithFunctions + TOODependencyQueries',
-	#classTraits : 'FamixTWithAnnotationTypes classTrait + FamixTWithClasses classTrait + FamixTWithFunctions classTrait + TOODependencyQueries classTrait',
+	#traits : 'FamixTWithAnnotationTypes + FamixTWithClasses + FamixTWithFunctions',
+	#classTraits : 'FamixTWithAnnotationTypes classTrait + FamixTWithClasses classTrait + FamixTWithFunctions classTrait',
 	#category : #'Famix-TypeScript-Entities-Entities'
 }
 

--- a/src/Famix-TypeScript-Entities/FamixTypeScriptEntity.class.st
+++ b/src/Famix-TypeScript-Entities/FamixTypeScriptEntity.class.st
@@ -77,6 +77,13 @@ FamixTypeScriptEntity >> isInvocation [
 ]
 
 { #category : #testing }
+FamixTypeScriptEntity >> isLocalVariable [
+
+	<generated>
+	^ false
+]
+
+{ #category : #testing }
 FamixTypeScriptEntity >> isMethod [
 
 	<generated>

--- a/src/Famix-TypeScript-Entities/FamixTypeScriptIndexedFileAnchor.class.st
+++ b/src/Famix-TypeScript-Entities/FamixTypeScriptIndexedFileAnchor.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #FamixTypeScriptIndexedFileAnchor,
-	#superclass : #FamixTypeScriptEntity,
+	#superclass : #FamixTypeScriptSourceAnchor,
 	#traits : 'FamixTIndexedFileNavigation',
 	#classTraits : 'FamixTIndexedFileNavigation classTrait',
 	#category : #'Famix-TypeScript-Entities-Entities'
@@ -9,7 +9,7 @@ Class {
 { #category : #meta }
 FamixTypeScriptIndexedFileAnchor class >> annotation [
 
-	<FMClass: #IndexedFileAnchor super: #FamixTypeScriptEntity>
+	<FMClass: #IndexedFileAnchor super: #FamixTypeScriptSourceAnchor>
 	<package: #FamixTypeScript>
 	<generated>
 	^self

--- a/src/Famix-TypeScript-Entities/FamixTypeScriptModel.class.st
+++ b/src/Famix-TypeScript-Entities/FamixTypeScriptModel.class.st
@@ -16,3 +16,9 @@ FamixTypeScriptModel class >> annotation [
 	<package: #FamixTypeScript>
 	<generated>
 ]
+
+{ #category : #testing }
+FamixTypeScriptModel class >> canBeImportedFromFile [
+	<generated>
+	^true
+]

--- a/src/Famix-TypeScript-Generator/FamixTypeScriptGenerator.class.st
+++ b/src/Famix-TypeScript-Generator/FamixTypeScriptGenerator.class.st
@@ -12,14 +12,10 @@ Class {
 		'parameterizedType',
 		'method',
 		'behaviouralEntity',
-		'leafEntity',
 		'structuralEntity',
-		'abstractFileAnchor',
 		'file',
-		'fileAnchor',
 		'folder',
 		'indexedFileAnchor',
-		'multipleFileAnchor',
 		'localVariable',
 		'attribute',
 		'invocation',
@@ -134,6 +130,7 @@ FamixTypeScriptGenerator >> defineHierarchy [
 	function --|> #TInvocable.
 	function --|> #TWithLocalVariables.
 
+	indexedFileAnchor --|> sourceAnchor.
 	indexedFileAnchor --|> #TIndexedFileNavigation.
 
 	inheritance --|> #TInheritance.

--- a/src/Famix-TypeScript-Generator/FamixTypeScriptGenerator.class.st
+++ b/src/Famix-TypeScript-Generator/FamixTypeScriptGenerator.class.st
@@ -179,7 +179,6 @@ FamixTypeScriptGenerator >> defineHierarchy [
 	scopingEntity --|> #TWithClasses.
 	scopingEntity --|> #TWithFunctions.
 	scopingEntity --|> #TWithAnnotationTypes.
-	scopingEntity --|> #TOODependencyQueries.
 
 	structuralEntity --|> #TStructuralEntity.
 	structuralEntity --|> #TWithDereferencedInvocations.

--- a/src/Famix-TypeScript-Generator/FamixTypeScriptModel.extension.st
+++ b/src/Famix-TypeScript-Generator/FamixTypeScriptModel.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #FamixTypeScriptModel }
-
-{ #category : #'*Famix-TypeScript-Generator' }
-FamixTypeScriptModel class >> canBeImportedFromFile [
-
-    ^ true
-]


### PR DESCRIPTION
Fixed the issues you had with moose-10:
- suppressed the reference to TOODependencyQuery (it was suppressed in https://github.com/moosetechnology/Famix/pull/473 and does not seem to be needed any more)
- removed dependency of TypeScript generator package to TypeScript entities package (no longer needed after https://github.com/moosetechnology/Famix/pull/507)
- corrected "definition" of IndexedFileanchor (added inheritance from sourceAnchor)
